### PR TITLE
Optionally exclude files or directories during git clean

### DIFF
--- a/config.py.template
+++ b/config.py.template
@@ -93,6 +93,3 @@ smtplogin = None
 
 #Whether or not to use SSL for smtp
 smtpssl = False
-
-#An optional list of files or directories to exclude when git clean is run.
-git_clean_exclude = None

--- a/doc/config.md
+++ b/doc/config.md
@@ -20,6 +20,8 @@ You can also specify:
                  the name of the local user running snap is.
 * `remote_user_key`: The location of the private ssh key to use when snapping. The private ssh key of
                      the local user running snap is used if this isn't specified.
+* `git_clean_exclude`: An optional list of files or directories to exclude when `git clean` is run
+                       during snap.
 
 ## Nodes
 

--- a/lib/project.py
+++ b/lib/project.py
@@ -19,7 +19,8 @@ def cache_path():
 
 class project:
 
-    def __init__(self,name,url,location,remote_user=getpass.getuser(),remote_user_key=None):
+    def __init__(self,name,url,location,remote_user=getpass.getuser(),remote_user_key=None,
+            git_clean_exclude=None):
         self.name     = name
         self.url      = url
         self.location = location
@@ -27,6 +28,7 @@ class project:
         self.key      = remote_user_key
         self.fetched  = False
         self.checked  = None
+        self.git_clean_exclude = git_clean_exclude
 
     def clone(self):
         '''Clones project into cache, unless it's already there'''
@@ -88,9 +90,8 @@ class project:
         '''Checks out the given branch in the local cache repo, does a hard reset'''
         clean_args = ["git","clean","-f","-d","-x"]
 
-        exclude = getattr(config, 'git_clean_exclude', None)
-        if exclude:
-            for name in exclude:
+        if self.git_clean_exclude:
+            for name in self.git_clean_exclude:
                 clean_args.append("-e")
                 clean_args.append(name)
 


### PR DESCRIPTION
Optionally exclude files or directories during git clean with the git_clean_exclude config property.

This is useful for us to keep from having to download Bower libs and Node modules that are used during
our build process, since these are not installed system-wide (and instead are installed per-user).
